### PR TITLE
Fix /dev/random problem: add initial value for status in waitpid()

### DIFF
--- a/judger-v2/Program.cpp
+++ b/judger-v2/Program.cpp
@@ -192,7 +192,7 @@ int Program::Compile(string source, int language) {
                 waitpid(cpid,&cstat,0);
                 return 2;
             }
-            if (WIFEXITED(cstat)) {
+            else if (WIFEXITED(cstat)) {
                 waitpid(cpid,&cstat,0);
                 LOG("Compiled");
                 break;
@@ -490,7 +490,7 @@ int Program::Excution() {
                 waitpid(wid,&rstat,0);
                 return 1;
             }
-            if (WIFEXITED(rstat)) {
+            else if (WIFEXITED(rstat)) {
                 waitpid(wid,&rstat,0);
                 LOG("Runned.");
                 break;


### PR DESCRIPTION
It seems that if there's no child process terminated, waitpid won't set status.
This will cause problem when status=0 initially, which is the case on the server
Also explains why everything is ok locally, where initail value of status is some random number
