### PR TITLE
Add Python3 and C++11 support

### DIFF
--- a/judger-v2/Interactive.cpp
+++ b/judger-v2/Interactive.cpp
@@ -1,7 +1,7 @@
-/* 
+/*
  * File:   Interactive.cpp
  * Author: payper
- * 
+ *
  * Created on 2014年4月24日, 下午5:41
  */
 
@@ -103,7 +103,11 @@ int Interactive::Excution() {
             execl("/usr/bin/ruby", "ruby", src_filename.c_str(), "-W", NULL);
             break;
           case PYLANG:
-            execl("/usr/bin/python", "python", exc_filename.c_str(), NULL);
+          case PY2LANG:
+            execl("/usr/bin/python2", "python2", exc_filename.c_str(), NULL);
+            break;
+          case PY3LANG:
+            execl("/usr/bin/python3", "python3", exc_filename.c_str(), NULL);
             break;
         }
         exit(0);

--- a/judger-v2/Interactive.cpp
+++ b/judger-v2/Interactive.cpp
@@ -102,7 +102,6 @@ int Interactive::Excution() {
           case RUBYLANG:
             execl("/usr/bin/ruby", "ruby", src_filename.c_str(), "-W", NULL);
             break;
-          case PYLANG:
           case PY2LANG:
             execl("/usr/bin/python2", "python2", exc_filename.c_str(), NULL);
             break;
@@ -355,8 +354,12 @@ int Interactive::Excution() {
             execl("/usr/bin/ruby", "ruby", validator_src_filename.c_str(), "-W",
                   NULL);
             break;
-          case PYLANG:
-            execl("/usr/bin/python", "python", validator_exc_filename.c_str(),
+          case PY2LANG:
+            execl("/usr/bin/python2", "python2", validator_exc_filename.c_str(),
+                  NULL);
+            break;
+          case PY3LANG:
+            execl("/usr/bin/python3", "python3", validator_exc_filename.c_str(),
                   NULL);
             break;
         }

--- a/judger-v2/Program.cpp
+++ b/judger-v2/Program.cpp
@@ -119,7 +119,7 @@ int Program::Compile(string source, int language) {
       case CPP11LANG:
         execl("/usr/bin/g++", "g++", src_filename.c_str(), "-o",
               exc_filename.c_str(), "-O", "-fno-asm", "-Wall", "-lm",
-              "--std=c++11x", NULL);
+              "--std=c++11", NULL);
         break;
       case CLANG:
         execl("/usr/bin/gcc", "gcc", src_filename.c_str(), "-o",

--- a/judger-v2/Program.cpp
+++ b/judger-v2/Program.cpp
@@ -145,7 +145,6 @@ int Program::Compile(string source, int language) {
         execl("/usr/bin/fpc", "fpc", src_filename.c_str(), "-o",
               exc_filename.c_str(), "-Co", "-Cr", "-Ct", "-Ci", NULL);
         break;
-      case PYLANG:
       case PY2LANG:
         execl(
             "/usr/bin/python2", "python2", "-c",
@@ -230,10 +229,9 @@ int Program::Compile(string source, int language) {
 
   if (!Checkfile(exc_filename)&&(language == CPPLANG || language == CLANG ||
       language == FPASLANG || language == FORTLANG || language == SMLLANG ||
-      language == CSLANG || language == JAVALANG || language == PYLANG ||
-      language == PY2LANG || language == PY3LANG || language == CPP11LANG ||
-      language == CLANGPPLANG || language == CLANGLANG ||
-      language == ADALANG)) {
+      language == CSLANG || language == JAVALANG || language == PY2LANG ||
+      language == PY3LANG || language == CPP11LANG || language == CLANGPPLANG ||
+      language == CLANGLANG || language == ADALANG)) {
     return 1;
   }
   return 0;
@@ -305,7 +303,6 @@ int Program::Excution() {
         case RUBYLANG:
           execl("/usr/bin/ruby", "ruby", src_filename.c_str(), "-W", NULL);
           break;
-        case PYLANG:
         case PY2LANG:
           execl("/usr/bin/python2", "python2", exc_filename.c_str(), NULL);
           break;

--- a/judger-v2/Program.cpp
+++ b/judger-v2/Program.cpp
@@ -116,6 +116,11 @@ int Program::Compile(string source, int language) {
         execl("/usr/bin/g++", "g++", src_filename.c_str(), "-o",
               exc_filename.c_str(), "-O", "-fno-asm", "-Wall", "-lm", NULL);
         break;
+      case CPP11LANG:
+        execl("/usr/bin/g++", "g++", src_filename.c_str(), "-o",
+              exc_filename.c_str(), "-O", "-fno-asm", "-Wall", "-lm",
+              "--std=c++11x", NULL);
+        break;
       case CLANG:
         execl("/usr/bin/gcc", "gcc", src_filename.c_str(), "-o",
               exc_filename.c_str(), "-O", "-fno-asm", "-Wall", "-lm", NULL);
@@ -141,8 +146,16 @@ int Program::Compile(string source, int language) {
               exc_filename.c_str(), "-Co", "-Cr", "-Ct", "-Ci", NULL);
         break;
       case PYLANG:
+      case PY2LANG:
         execl(
-            "/usr/bin/python", "python", "-c",
+            "/usr/bin/python2", "python2", "-c",
+            ((string) "import py_compile; py_compile.compile(\'" +
+                src_filename + "\')").c_str(),
+            NULL);
+        break;
+      case PY3LANG:
+        execl(
+            "/usr/bin/python3", "python3", "-c",
             ((string) "import py_compile; py_compile.compile(\'" +
                 src_filename + "\')").c_str(),
             NULL);
@@ -218,6 +231,7 @@ int Program::Compile(string source, int language) {
   if (!Checkfile(exc_filename)&&(language == CPPLANG || language == CLANG ||
       language == FPASLANG || language == FORTLANG || language == SMLLANG ||
       language == CSLANG || language == JAVALANG || language == PYLANG ||
+      language == PY2LANG || language == PY3LANG || language == CPP11LANG ||
       language == CLANGPPLANG || language == CLANGLANG ||
       language == ADALANG)) {
     return 1;
@@ -267,6 +281,7 @@ int Program::Excution() {
 
       switch (language) {
         case CPPLANG:
+        case CPP11LANG:
         case CLANG:
         case CLANGLANG:
         case CLANGPPLANG:
@@ -291,7 +306,11 @@ int Program::Excution() {
           execl("/usr/bin/ruby", "ruby", src_filename.c_str(), "-W", NULL);
           break;
         case PYLANG:
-          execl("/usr/bin/python", "python", exc_filename.c_str(), NULL);
+        case PY2LANG:
+          execl("/usr/bin/python2", "python2", exc_filename.c_str(), NULL);
+          break;
+        case PY3LANG:
+          execl("/usr/bin/python3", "python3", exc_filename.c_str(), NULL);
           break;
       }
       exit(0);

--- a/judger-v2/Program.cpp
+++ b/judger-v2/Program.cpp
@@ -148,15 +148,15 @@ int Program::Compile(string source, int language) {
       case PY2LANG:
         execl(
             "/usr/bin/python2", "python2", "-c",
-            ((string) "import py_compile; py_compile.compile(\'" +
-                src_filename + "\')").c_str(),
+            ((string) "import py_compile; py_compile.compile('" +
+                src_filename + "')").c_str(),
             NULL);
         break;
       case PY3LANG:
         execl(
             "/usr/bin/python3", "python3", "-c",
-            ((string) "import py_compile; py_compile.compile(\'" +
-                src_filename + "\')").c_str(),
+            ((string) "import py_compile; py_compile.compile('" +
+                src_filename + "', cfile='" + exc_filename + "')").c_str(),
             NULL);
         break;
       case CSLANG:

--- a/judger-v2/chaclient.cpp
+++ b/judger-v2/chaclient.cpp
@@ -345,6 +345,7 @@ void dojudge(int type) {
   usrprogram->Sethas_input(true);
   usrprogram->Setin_filename(inpfile);
   usrprogram->Setout_filename(CONFIG->GetTmpfile_path() + tmpnam());
+  usrprogram->Seterr_filename(CONFIG->GetTmpfile_path() + tmpnam());
   if (type == NEED_JUDGE)
     usrprogram->Settotal_time_limit(bott->Gettime_limit());
   else usrprogram->Settotal_time_limit(bott->Getcase_limit() * in_files.size());

--- a/judger-v2/chaclient.h
+++ b/judger-v2/chaclient.h
@@ -59,7 +59,7 @@ using namespace std;
 #define CLANG 2
 #define JAVALANG 3
 #define FPASLANG 4
-#define PYLANG 5
+#define PY2LANG 5
 #define CSLANG 6
 #define FORTLANG 7
 #define PERLLANG 8
@@ -70,10 +70,9 @@ using namespace std;
 #define VCPPLANG 13
 #define CLANGLANG 14
 #define CLANGPPLANG 15
-#define PY2LANG 16
-#define PY3LANG 17
-#define CPP11LANG 18
-#define MAX_LANG_NUM 18
+#define PY3LANG 16
+#define CPP11LANG 17
+#define MAX_LANG_NUM 17
 
 #define AC_STATUS 0
 #define CE_STATUS 1

--- a/judger-v2/chaclient.h
+++ b/judger-v2/chaclient.h
@@ -70,7 +70,10 @@ using namespace std;
 #define VCPPLANG 13
 #define CLANGLANG 14
 #define CLANGPPLANG 15
-#define MAX_LANG_NUM 15
+#define PY2LANG 16
+#define PY3LANG 17
+#define CPP11LANG 18
+#define MAX_LANG_NUM 18
 
 #define AC_STATUS 0
 #define CE_STATUS 1

--- a/judger-v2/program_init.h
+++ b/judger-v2/program_init.h
@@ -175,15 +175,14 @@ void init_error() {
 }
 
 void init_others() {
-  vmlang[JAVALANG] = vmlang[PYLANG] = vmlang[PY2LANG] = vmlang[PY3LANG] =
+  vmlang[JAVALANG] = vmlang[PY2LANG] = vmlang[PY3LANG] =
       vmlang[PERLLANG] = vmlang[RUBYLANG] = true;
 
   src_extension[CPPLANG] = src_extension[CPP11LANG] = ".cpp";
   src_extension[CLANG] = ".c";
   src_extension[JAVALANG] = ".java";
   src_extension[FPASLANG] = ".pas";
-  src_extension[PYLANG] = src_extension[PY2LANG] = src_extension[PY3LANG] =
-      ".py";
+  src_extension[PY2LANG] = src_extension[PY3LANG] = ".py";
   src_extension[CSLANG] = ".cs";
   src_extension[FORTLANG] = ".f";
   src_extension[PERLLANG] = ".pl";
@@ -198,8 +197,7 @@ void init_others() {
   exc_extension[CLANG] = ".out";
   exc_extension[JAVALANG] = ".class";
   exc_extension[FPASLANG] = ".out";
-  exc_extension[PYLANG] = exc_extension[PY2LANG] = exc_extension[PY3LANG] =
-      ".pyc";
+  exc_extension[PY2LANG] = exc_extension[PY3LANG] = ".pyc";
   exc_extension[CSLANG] = ".exe";
   exc_extension[FORTLANG] = ".out";
   exc_extension[SMLLANG] = ".out";

--- a/judger-v2/program_init.h
+++ b/judger-v2/program_init.h
@@ -175,14 +175,15 @@ void init_error() {
 }
 
 void init_others() {
-  vmlang[JAVALANG] = vmlang[PYLANG] =
+  vmlang[JAVALANG] = vmlang[PYLANG] = vmlang[PY2LANG] = vmlang[PY3LANG] =
       vmlang[PERLLANG] = vmlang[RUBYLANG] = true;
 
-  src_extension[CPPLANG] = ".cpp";
+  src_extension[CPPLANG] = src_extension[CPP11LANG] = ".cpp";
   src_extension[CLANG] = ".c";
   src_extension[JAVALANG] = ".java";
   src_extension[FPASLANG] = ".pas";
-  src_extension[PYLANG] = ".py";
+  src_extension[PYLANG] = src_extension[PY2LANG] = src_extension[PY3LANG] =
+      ".py";
   src_extension[CSLANG] = ".cs";
   src_extension[FORTLANG] = ".f";
   src_extension[PERLLANG] = ".pl";
@@ -193,11 +194,12 @@ void init_others() {
   src_extension[CLANGPPLANG] = ".cpp";
 
 
-  exc_extension[CPPLANG] = ".out";
+  exc_extension[CPPLANG] = exc_extension[CPP11LANG] = ".out";
   exc_extension[CLANG] = ".out";
   exc_extension[JAVALANG] = ".class";
   exc_extension[FPASLANG] = ".out";
-  exc_extension[PYLANG] = ".pyc";
+  exc_extension[PYLANG] = exc_extension[PY2LANG] = exc_extension[PY3LANG] =
+      ".pyc";
   exc_extension[CSLANG] = ".exe";
   exc_extension[FORTLANG] = ".out";
   exc_extension[SMLLANG] = ".out";


### PR DESCRIPTION
Though exact reason uncovered, Python3 seems to require a work stdout, and err_filename is forgotten to set...

There're still problems with Python3, like runtime errors cannot be detected and result in wrong answer. Still need further investigation.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bnuacm/bnuoj-backend/9)
<!-- Reviewable:end -->
